### PR TITLE
Actualiza rol shell y kitty con tema y fuente nerd font meslo

### DIFF
--- a/localsystem.yml
+++ b/localsystem.yml
@@ -8,4 +8,4 @@
     - shell
     - vim
     - kitty
-
+    

--- a/roles/kitty/defaults/main.yml
+++ b/roles/kitty/defaults/main.yml
@@ -7,9 +7,9 @@ dotfiles_repo: git@github.com:jorgearma1982/dotfiles.git
 dotfiles_dest: "{{ lookup('env','HOME') }}/.dotfiles"
 
 # Kitty themes repository (used to fetch community themes)
-kitty_themes_repo: "https://github.com/dexpota/kitty-themes.git"
+kitty_themes_repo: "https://github.com/kovidgoyal/kitty-themes.git"
 kitty_themes_dest: "{{ kitty_config_dir }}/kitty-themes"
-# Path inside the themes repo to the Dracula theme file
-kitty_theme_source: "themes/Dracula.conf"
+# Path inside the themes repo to the theme file
+kitty_theme_source: "themes/Eldritch.conf"
 # Path for the symlink that kitty will read as the active theme
 kitty_theme_link: "{{ kitty_config_dir }}/theme.conf"

--- a/roles/kitty/meta/main.yml
+++ b/roles/kitty/meta/main.yml
@@ -13,3 +13,4 @@ galaxy_info:
     - desktop
 dependencies:
   - role: common
+  - role: shell

--- a/roles/shell/tasks/main.yml
+++ b/roles/shell/tasks/main.yml
@@ -3,3 +3,5 @@
 
 - name: Incluye las tareas para desplegar zsh
   include_tasks: "zsh.yml"
+  tags:
+    - zsh

--- a/roles/shell/tasks/zsh.yml
+++ b/roles/shell/tasks/zsh.yml
@@ -1,69 +1,72 @@
 ---
 # tasks file for zsh shell
-
-- name: Asegura que zsh esté instalado
+- name: Asegura que el paquete del shell zsh y stow estén instalados
   community.general.homebrew:
     name:
       - zsh
       - stow
     state: present
-  become: false
+  tags:
+    - zsh
 
 - name: Configurar zsh como shell por defecto
   ansible.builtin.user:
     name: "{{ ansible_user }}"
     shell: /bin/zsh
   become: true
+  tags:
+    - zsh
 
 - name: Descargar el script de instalación de ohmyzsh
   ansible.builtin.get_url:
     url: https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh
     dest: "/tmp/install_ohmyzsh.sh"
     mode: '0755'
-  become: false
+  tags:
+    - zsh
 
 - name: Instalar ohmyzsh con argumento 
   ansible.builtin.script:
     cmd: "/tmp/install_ohmyzsh.sh --unattended"
   args:
     creates: "/Users/{{ ansible_user }}/.oh-my-zsh"
-  become: false
+  tags:
+    - zsh
 
 - name: Remueve .zshrc por defecto si existe
   ansible.builtin.file:
     path: "/Users/{{ ansible_user }}/.zshrc"
     state: absent
-  become: false
+  tags:
+    - zsh
 
 - name: Instala tema powerlevel10k
   ansible.builtin.git:
     repo: https://github.com/romkatv/powerlevel10k.git
     dest: "/Users/{{ ansible_user }}/.oh-my-zsh/custom/themes/powerlevel10k"
     depth: 1
-  become: false
+  tags:
+    - zsh
 
-- name: Descarga la fuente NerdFonts Meslo
-  ansible.builtin.get_url:
-    url: https://github.com/ryanoasis/nerd-fonts/releases/download/v2.3.3/Meslo.zip
-    dest: "/tmp/Meslo.zip"
-    mode: '0644'
-  become: false
-
-- name: Descomprime la fuente NerdFonts Meslo
-  ansible.builtin.unarchive:
-    src: "/tmp/Meslo.zip"
-    dest: "/Users/{{ ansible_user }}/Library/Fonts/"
-  become: false
+- name: Asegurar que el paquete de la fuente Nerd Fonts Meslo
+  homebrew_cask:
+    path: /opt/homebrew/bin/brew
+    name: font-meslo-lg-nerd-font
+    state: present
+  tags:
+    - zsh
 
 - name: Clona repositorio dotfiles
   ansible.builtin.git:
     repo: "{{ dotfiles_repo }}"
     dest: "/Users/{{ ansible_user }}/.dotfiles"
     version: main
-  become: false
+  tags:
+    - zsh
 
 - name: Ejecuta stow para zsh
   ansible.builtin.command:
     cmd: "stow zsh"
     chdir: "/Users/{{ ansible_user }}/.dotfiles"
-  become: false
+  tags:
+    - zsh


### PR DESCRIPTION
Cambia el método para instalar las fuentes Nerd Fonts usando brew, añade tags zsh al rol shell, actualiza el repositorio de los temas de kitty y usa el tema Eldritch, limpia comentarios y sentencias inecesarias para mejorar claridad.

Cierra #10.