### PR TITLE
Añade rol para desplegar vscode, con sus extensiones y configuraciones personalizadas

### DIFF
--- a/localsystem.yml
+++ b/localsystem.yml
@@ -8,4 +8,5 @@
     - shell
     - vim
     - kitty
+    - vscode
     

--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -7,7 +7,6 @@ homebrew_taps:
   - AKSarav/kubenodeusage
 
 homebrew_cask_packages:
-  - visual-studio-code
   - localsend
 
 homebrew_browsers_packages:

--- a/roles/vscode/README.md
+++ b/roles/vscode/README.md
@@ -1,0 +1,39 @@
+vscode
+======
+
+Tasks to setup vscode on macOS.
+
+Requirements
+------------
+
+MacOS based system.
+
+Role Variables
+--------------
+
+These are default variables for this role:
+
+- `vscode_extensions` (list): list of extension identifiers to install.
+- `dotfiles_repo`: git repo containing dotfiles.
+
+Dependencies
+------------
+
+Example Playbook
+----------------
+
+To use this role, just include it in your playbook, for example:
+
+    - hosts: desktop
+      roles:
+         - vscode
+
+License
+-------
+
+MIT
+
+Author Information
+------------------
+
+Please any question, please contact the author at: <jorge.medina@kronops.com.mx>.

--- a/roles/vscode/defaults/main.yml
+++ b/roles/vscode/defaults/main.yml
@@ -1,0 +1,22 @@
+---
+# Default variables for the vscode role
+
+# List of VSCode extensions to install (examples: Dev Containers, Ansible)
+vscode_extensions:
+  - zainchen.json
+  - davidanson.vscode-markdownlint
+  - ms-vscode-remote.remote-containers
+  - ms-vscode.remote-explorer
+  - ms-vscode-remote.remote-ssh
+  - redhat.ansible
+  - redhat.vscode-yaml
+  - hashicorp.terraform
+  - 4ops.terraform
+  - editorconfig.editorconfig
+  - github.vscode-github-actions
+  - github.vscode-pull-request-github
+  - telokis.theme-dracula-at-dusk
+  - github.copilot-chat
+
+# Repo de dotfiles (personaliza a tu repositorio)
+dotfiles_repo: git@github.com:jorgearma1982/dotfiles.git

--- a/roles/vscode/meta/main.yml
+++ b/roles/vscode/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: Jorge Medina
+  description: Tasks to setup vscode on macOS
+  company: KronOps
+  license: MIT
+  min_ansible_version: 2.8
+  platforms:
+  - name: macos
+    versions:
+    - sequoia
+  categories:
+  - destkop
+dependencies:
+  - role: common
+  - role: shell

--- a/roles/vscode/tasks/main.yml
+++ b/roles/vscode/tasks/main.yml
@@ -1,0 +1,45 @@
+---
+# Tasks for the vscode role
+
+- name: Asegura que el paquete de Visual Studio Code está instalado
+  community.general.homebrew_cask:
+    name: visual-studio-code
+    state: present
+  tags:
+    - vscode
+
+- name: Obtener lista de extensiones instaladas
+  ansible.builtin.command:
+    cmd: "code --list-extensions"
+  register: installed_exts
+  failed_when: false
+  changed_when: false
+  tags:
+    - vscode
+
+- name: Instalar extensiones de VSCode
+  ansible.builtin.command:
+    cmd: "code --install-extension {{ item }} --force"
+  loop: "{{ vscode_extensions }}"
+  register: install_results
+  failed_when: false
+  loop_control:
+    label: "{{ item }}"
+  tags:
+    - vscode
+
+- name: Clonar repositorio dotfiles
+  ansible.builtin.git:
+    repo: "{{ dotfiles_repo }}"
+    dest: "{{ ansible_facts.env.HOME }}/.dotfiles"
+    version: main
+  tags:
+    - vscode
+
+- name: Ejecutar stow para desplegar vscode desde dotfiles
+  ansible.builtin.command:
+    cmd: "stow vscode"
+  args:
+    chdir: "{{ ansible_facts.env.HOME }}/.dotfiles"
+  tags:
+    - vscode


### PR DESCRIPTION
Introduce nuevo rol para desplegar vscode en macos, incluyendo la instalación de extensiones y configuraciones personalizadas desde dotfiles.

Cierra #5 .